### PR TITLE
ROC-2760: Remove feign client from spring factories and add health indicator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.6'
+version '0.0.7'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  uk.gov.hmcts.reform.authorisation.healthcheck.ServiceAuthHealthIndicator


### PR DESCRIPTION
This PR fixes the configuration issue in spring factories. Removed feign client from spring factories and add health indicator