### PR TITLE
Fix guava version for checkstyle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ dependencyManagement {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
     dependencies {
-        dependency group: 'com.google.guava', name: 'guava', version: '23.0'
+        dependency group: 'com.google.guava', name: 'guava', version: '23.2-jre'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-feign'
     compile group: 'com.netflix.feign', name: 'feign-jackson', version: '8.18.0'
-    compile group: 'com.google.guava', name: 'guava', version: '23.0'
+    compile group: 'com.google.guava', name: 'guava', version: '23.2-jre'
     compile group: 'com.warrenstrange', name: 'googleauth', version: '1.1.2'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
@@ -133,6 +133,9 @@ dependencies {
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+    dependencies {
+        dependency group: 'com.google.guava', name: 'guava', version: '23.0'
     }
 }
 


### PR DESCRIPTION
Before this change, checkstyle used and old version on Guava (that comes with Spring), while it relies on a function that was introduced in a later version.
This causes exception when checking javadoc comments (for example here: https://github.com/hmcts/service-auth-provider-java-client/pull/14)
