### PR TITLE
Review docblock after library class clash

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationHealthApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationHealthApi.java
@@ -6,8 +6,7 @@ import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import uk.gov.hmcts.reform.authorisation.healthcheck.InternalHealth;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -17,11 +16,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
         configuration = ServiceAuthorisationHealthApi.ServiceAuthConfiguration.class)
 public interface ServiceAuthorisationHealthApi {
 
-    @RequestMapping(
-            method = RequestMethod.GET,
-            value = "/health",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_UTF8_VALUE
-    )
+    @GetMapping(value = "/health", headers = CONTENT_TYPE + "=" + APPLICATION_JSON_UTF8_VALUE)
     InternalHealth health();
 
     class ServiceAuthConfiguration {

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/AuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/AuthTokenGenerator.java
@@ -1,5 +1,10 @@
 package uk.gov.hmcts.reform.authorisation.generators;
 
 public interface AuthTokenGenerator {
+
+    /**
+     * Request for the service auth token.
+     * @return Service auth token for the micro service
+     */
     String generate();
 }

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/AutorefreshingJwtAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/AutorefreshingJwtAuthTokenGenerator.java
@@ -23,7 +23,8 @@ public class AutorefreshingJwtAuthTokenGenerator implements AuthTokenGenerator {
     /**
      * Constructor.
      *
-     * @param refreshTimeDelta time before actual expiry date in JWT when a new token should be requested.
+     * @param generator Token generator for automatic refresh
+     * @param refreshTimeDelta Time before actual expiry date in JWT when a new token should be requested.
      */
     public AutorefreshingJwtAuthTokenGenerator(
         ServiceAuthTokenGenerator generator,

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
@@ -24,10 +24,6 @@ public class ServiceAuthTokenGenerator implements AuthTokenGenerator {
         this.googleAuthenticator = new GoogleAuthenticator();
     }
 
-    /***
-     *
-     * @return Service Auth token for the micro service
-     */
     @Override
     public String generate() {
         final String oneTimePassword = format("%06d", googleAuthenticator.getTotpPassword(secret));

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/validators/AuthTokenValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/validators/AuthTokenValidator.java
@@ -4,7 +4,16 @@ import java.util.List;
 
 interface AuthTokenValidator {
 
+    /**
+     * Validate bearer token.
+     * @param token Bearer token
+     */
     void validate(String token);
 
+    /**
+     * Validate bearer token with optional roles.
+     * @param token Bearer token
+     * @param roles Roles
+     */
     void validate(String token, List<String> roles);
 }


### PR DESCRIPTION
Guava 23.0 caused an issue for our default code style ruleset to fail validate files with docblock in them. Since fix is in #15 , re-adding left out docblock from #6 and reviewing current interface objects