### PR TITLE
Added content length with value 0 which is required by windows IIS server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.4.2'
+version '0.4.3'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
@@ -12,7 +12,8 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 public interface ServiceAuthorisationApi {
     @PostMapping(value = "/lease")
     String serviceToken(@RequestParam("microservice") final String microservice,
-                        @RequestParam("oneTimePassword") final String oneTimePassword);
+                        @RequestParam("oneTimePassword") final String oneTimePassword,
+                        @RequestHeader("Content-Length") final int contentLength);
 
     @SuppressWarnings("PMD.UseVarargs")
     @GetMapping(value = "/authorisation-check")

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.authorisation;
 
+import feign.Headers;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,9 +12,9 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 @FeignClient(name = "idam-s2s-auth", url = "${idam.s2s-auth.url}")
 public interface ServiceAuthorisationApi {
     @PostMapping(value = "/lease")
+    @Headers("Content-Length: 0")
     String serviceToken(@RequestParam("microservice") final String microservice,
-                        @RequestParam("oneTimePassword") final String oneTimePassword,
-                        @RequestHeader("Content-Length") final int contentLength);
+                        @RequestParam("oneTimePassword") final String oneTimePassword);
 
     @SuppressWarnings("PMD.UseVarargs")
     @GetMapping(value = "/authorisation-check")

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
@@ -27,6 +27,6 @@ public class ServiceAuthTokenGenerator implements AuthTokenGenerator {
     @Override
     public String generate() {
         final String oneTimePassword = format("%06d", googleAuthenticator.getTotpPassword(secret));
-        return serviceAuthorisationApi.serviceToken(this.microService, oneTimePassword, 0);
+        return serviceAuthorisationApi.serviceToken(this.microService, oneTimePassword);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
@@ -27,6 +27,6 @@ public class ServiceAuthTokenGenerator implements AuthTokenGenerator {
     @Override
     public String generate() {
         final String oneTimePassword = format("%06d", googleAuthenticator.getTotpPassword(secret));
-        return serviceAuthorisationApi.serviceToken(this.microService, oneTimePassword);
+        return serviceAuthorisationApi.serviceToken(this.microService, oneTimePassword,0);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
@@ -14,9 +14,9 @@ public class ServiceAuthTokenGenerator implements AuthTokenGenerator {
     private final GoogleAuthenticator googleAuthenticator;
 
     public ServiceAuthTokenGenerator(
-            final String secret,
-            final String microService,
-            final ServiceAuthorisationApi serviceAuthorisationApi
+        final String secret,
+        final String microService,
+        final ServiceAuthorisationApi serviceAuthorisationApi
     ) {
         this.secret = secret;
         this.microService = microService;
@@ -27,6 +27,6 @@ public class ServiceAuthTokenGenerator implements AuthTokenGenerator {
     @Override
     public String generate() {
         final String oneTimePassword = format("%06d", googleAuthenticator.getTotpPassword(secret));
-        return serviceAuthorisationApi.serviceToken(this.microService, oneTimePassword,0);
+        return serviceAuthorisationApi.serviceToken(this.microService, oneTimePassword, 0);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
@@ -18,7 +18,7 @@ public class ServiceAuthTokenGeneratorTest {
         final String secret = "123456";
         final String microService = "microservice";
         final String serviceAuthToken = "service-auth-token";
-        when(serviceAuthorisationApi.serviceToken(eq(microService), anyString())).thenReturn(serviceAuthToken);
+        when(serviceAuthorisationApi.serviceToken(eq(microService), anyString(),eq(0))).thenReturn(serviceAuthToken);
 
         //when
         final ServiceAuthTokenGenerator serviceAuthTokenGenerator = new ServiceAuthTokenGenerator(secret,

--- a/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
@@ -18,7 +18,7 @@ public class ServiceAuthTokenGeneratorTest {
         final String secret = "123456";
         final String microService = "microservice";
         final String serviceAuthToken = "service-auth-token";
-        when(serviceAuthorisationApi.serviceToken(eq(microService), anyString(), eq(0))).thenReturn(serviceAuthToken);
+        when(serviceAuthorisationApi.serviceToken(eq(microService), anyString())).thenReturn(serviceAuthToken);
 
         //when
         final ServiceAuthTokenGenerator serviceAuthTokenGenerator = new ServiceAuthTokenGenerator(secret,

--- a/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
@@ -18,11 +18,11 @@ public class ServiceAuthTokenGeneratorTest {
         final String secret = "123456";
         final String microService = "microservice";
         final String serviceAuthToken = "service-auth-token";
-        when(serviceAuthorisationApi.serviceToken(eq(microService), anyString(),eq(0))).thenReturn(serviceAuthToken);
+        when(serviceAuthorisationApi.serviceToken(eq(microService), anyString(), eq(0))).thenReturn(serviceAuthToken);
 
         //when
         final ServiceAuthTokenGenerator serviceAuthTokenGenerator = new ServiceAuthTokenGenerator(secret,
-                microService, serviceAuthorisationApi);
+            microService, serviceAuthorisationApi);
 
         final String result = serviceAuthTokenGenerator.generate();
 


### PR DESCRIPTION
- IIS throws `status 411 reading ServiceAuthorisationApi#serviceToken(String,String);` if you make a HTTP call without body.

- Hence we need to add content length with value 0 as header.