### PR TITLE
Update client to use spring annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.5.1'
+version '0.5.2'
 
 checkstyle {
     maxWarnings = 0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Mar 20 19:38:55 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,3 @@
-#Tue Mar 20 19:38:55 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
@@ -14,15 +14,8 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 @FeignClient(name = "idam-s2s-auth", url = "${idam.s2s-auth.url}")
 public interface ServiceAuthorisationApi {
     @PostMapping(value = "/lease")
-<<<<<<< HEAD
     String serviceToken(@RequestBody Map<String, String> signIn,
                         @RequestHeader("Content-Type") String contentType);
-=======
-    @Headers("Content-Type: application/json")
-    @Body("\"%7B\"microservice\":\"{microservice}\",\"one_time_password\":\"{oneTimePassword}\"%7D")
-    String serviceToken(@RequestParam("microservice") final String microservice,
-                        @RequestParam("oneTimePassword") final String oneTimePassword);
->>>>>>> update key in the request body
 
     @SuppressWarnings("PMD.UseVarargs")
     @GetMapping(value = "/authorisation-check")

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.authorisation;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +16,8 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @FeignClient(name = "idam-s2s-auth", url = "${idam.s2s-auth.url}")
 public interface ServiceAuthorisationApi {
-    @RequestMapping(value = "/lease", consumes = MimeTypeUtils.APPLICATION_JSON_VALUE, method = RequestMethod.POST)
+    
+    @PostMapping(value = "/lease", consumes = MimeTypeUtils.APPLICATION_JSON_VALUE)
     String serviceToken(@RequestBody Map<String, String> signIn);
 
     @SuppressWarnings("PMD.UseVarargs")

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
@@ -14,8 +14,15 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 @FeignClient(name = "idam-s2s-auth", url = "${idam.s2s-auth.url}")
 public interface ServiceAuthorisationApi {
     @PostMapping(value = "/lease")
+<<<<<<< HEAD
     String serviceToken(@RequestBody Map<String, String> signIn,
                         @RequestHeader("Content-Type") String contentType);
+=======
+    @Headers("Content-Type: application/json")
+    @Body("\"%7B\"microservice\":\"{microservice}\",\"one_time_password\":\"{oneTimePassword}\"%7D")
+    String serviceToken(@RequestParam("microservice") final String microservice,
+                        @RequestParam("oneTimePassword") final String oneTimePassword);
+>>>>>>> update key in the request body
 
     @SuppressWarnings("PMD.UseVarargs")
     @GetMapping(value = "/authorisation-check")

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
@@ -16,7 +14,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @FeignClient(name = "idam-s2s-auth", url = "${idam.s2s-auth.url}")
 public interface ServiceAuthorisationApi {
-    
+
     @PostMapping(value = "/lease", consumes = MimeTypeUtils.APPLICATION_JSON_VALUE)
     String serviceToken(@RequestBody Map<String, String> signIn);
 

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.authorisation;
 
 import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
@@ -13,9 +15,8 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @FeignClient(name = "idam-s2s-auth", url = "${idam.s2s-auth.url}")
 public interface ServiceAuthorisationApi {
-    @PostMapping(value = "/lease")
-    String serviceToken(@RequestBody Map<String, String> signIn,
-                        @RequestHeader("Content-Type") String contentType);
+    @RequestMapping(value = "/lease", consumes = MimeTypeUtils.APPLICATION_JSON_VALUE, method = RequestMethod.POST)
+    String serviceToken(@RequestBody Map<String, String> signIn);
 
     @SuppressWarnings("PMD.UseVarargs")
     @GetMapping(value = "/authorisation-check")

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.authorisation.generators;
 
 import com.warrenstrange.googleauth.GoogleAuthenticator;
-import org.springframework.util.MimeTypeUtils;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 
 import java.util.HashMap;
@@ -36,6 +35,6 @@ public class ServiceAuthTokenGenerator implements AuthTokenGenerator {
         signInDetails.put("microservice", this.microService);
         signInDetails.put("oneTimePassword", oneTimePassword);
 
-        return serviceAuthorisationApi.serviceToken(signInDetails, MimeTypeUtils.APPLICATION_JSON_VALUE);
+        return serviceAuthorisationApi.serviceToken(signInDetails);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGeneratorTest.java
@@ -6,7 +6,6 @@ import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyMapOf;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 public class ServiceAuthTokenGeneratorTest {
@@ -19,7 +18,7 @@ public class ServiceAuthTokenGeneratorTest {
         final String microService = "microservice";
         final String serviceAuthToken = "service-auth-token";
 
-        when(serviceAuthorisationApi.serviceToken(anyMapOf(String.class, String.class), anyString()))
+        when(serviceAuthorisationApi.serviceToken(anyMapOf(String.class, String.class)))
             .thenReturn(serviceAuthToken);
 
         //when


### PR DESCRIPTION
- There is a bug in Spring Feign Client due to which we cannot set Header using `@RequestHeader` annotation.https://github.com/spring-cloud/spring-cloud-netflix/issues/1902

- We can only set it via consumes attribute of Request mapping.