### PR TITLE
ROC-3551: Add a proper S2S health check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.0'
+version '1.0.1'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/healthcheck/ServiceAuthHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/healthcheck/ServiceAuthHealthIndicator.java
@@ -40,22 +40,13 @@ public class ServiceAuthHealthIndicator implements HealthIndicator {
 
     @Override
     public Health health() {
-        return check();
-    }
-
-    private Health check() {
         try {
             InternalHealth internalHealth = this.serviceAuthorisationHealthApi.health();
             if (!internalHealth.getStatus().getCode().equalsIgnoreCase(Status.UP.getCode())) {
                 return new Health.Builder(internalHealth.getStatus()).build();
             } else {
                 String token = generateToken();
-                String serviceName = this.serviceAuthorisationApi.getServiceName(token);
-                if (!this.microService.equalsIgnoreCase(serviceName)) {
-                    String msg = "S2S token validation has failed - service name does not match";
-                    LOGGER.error(msg);
-                    return Health.down().withDetail("reason", msg).build();
-                }
+                this.serviceAuthorisationApi.getServiceName(token);
                 return Health.up().build();
             }
         } catch (Exception ex) {

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/healthcheck/ServiceAuthHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/healthcheck/ServiceAuthHealthIndicator.java
@@ -45,8 +45,7 @@ public class ServiceAuthHealthIndicator implements HealthIndicator {
             if (!internalHealth.getStatus().getCode().equalsIgnoreCase(Status.UP.getCode())) {
                 return new Health.Builder(internalHealth.getStatus()).build();
             } else {
-                String token = generateToken();
-                this.serviceAuthorisationApi.getServiceName(token);
+                this.serviceAuthorisationApi.getServiceName(generateToken());
                 return Health.up().build();
             }
         } catch (Exception ex) {

--- a/src/main/java/uk/gov/hmcts/reform/authorisation/healthcheck/ServiceAuthHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/healthcheck/ServiceAuthHealthIndicator.java
@@ -3,11 +3,16 @@ package uk.gov.hmcts.reform.authorisation.healthcheck;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationHealthApi;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
 
 @Component
 @ConditionalOnProperty(prefix = "idam.s2s-auth", name = "url")
@@ -16,20 +21,55 @@ public class ServiceAuthHealthIndicator implements HealthIndicator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceAuthHealthIndicator.class);
 
     private final ServiceAuthorisationHealthApi serviceAuthorisationHealthApi;
+    private final String secret;
+    private final String microService;
+    private final ServiceAuthorisationApi serviceAuthorisationApi;
 
     @Autowired
-    public ServiceAuthHealthIndicator(final ServiceAuthorisationHealthApi serviceAuthorisationHealthApi) {
+    public ServiceAuthHealthIndicator(
+            ServiceAuthorisationHealthApi serviceAuthorisationHealthApi,
+            @Value("${idam.s2s-auth.totp_secret}") String secret,
+            @Value("${idam.s2s-auth.microservice}") String microService,
+            ServiceAuthorisationApi serviceAuthorisationApi
+    ) {
         this.serviceAuthorisationHealthApi = serviceAuthorisationHealthApi;
+        this.secret = secret;
+        this.microService = microService;
+        this.serviceAuthorisationApi = serviceAuthorisationApi;
     }
 
     @Override
     public Health health() {
+        return check();
+    }
+
+    private Health check() {
         try {
             InternalHealth internalHealth = this.serviceAuthorisationHealthApi.health();
-            return new Health.Builder(internalHealth.getStatus()).build();
+            if (!internalHealth.getStatus().getCode().equalsIgnoreCase(Status.UP.getCode())) {
+                return new Health.Builder(internalHealth.getStatus()).build();
+            } else {
+                String token = generateToken();
+                String serviceName = this.serviceAuthorisationApi.getServiceName(token);
+                if (!this.microService.equalsIgnoreCase(serviceName)) {
+                    String msg = "S2S token validation has failed - service name does not match";
+                    LOGGER.error(msg);
+                    return Health.down().withDetail("reason", msg).build();
+                }
+                return Health.up().build();
+            }
         } catch (Exception ex) {
             LOGGER.error("Error on service auth healthcheck", ex);
             return Health.down(ex).build();
         }
+    }
+
+    private String generateToken() {
+        AuthTokenGenerator authTokenGenerator = AuthTokenGeneratorFactory.createDefaultGenerator(
+                secret,
+                microService,
+                serviceAuthorisationApi
+        );
+        return authTokenGenerator.generate();
     }
 }


### PR DESCRIPTION
In this PR, health check indicator is leasing new S2S token via `/lease` endpoint and then retrieving service name via `/details` endpoint ti identify health of `service-auth-provider-api`

Jira: [ROC-3551](https://tools.hmcts.net/jira/browse/ROC-3551)