### PR TITLE
Change default refreshTimeDelta to 5minutes instead of 0 seconds.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/authorisation/generators/AutorefreshingJwtAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/authorisation/generators/AutorefreshingJwtAuthTokenGenerator.java
@@ -35,7 +35,7 @@ public class AutorefreshingJwtAuthTokenGenerator implements AuthTokenGenerator {
     }
 
     public AutorefreshingJwtAuthTokenGenerator(AuthTokenGenerator generator) {
-        this(generator, Duration.ZERO);
+        this(generator, Duration.ofMinutes(5));
     }
 
     @Override


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-3348


### Change description ###
NFD service (and possibly others) are seeing that the refresh time is set to zero on our service and this is due to calling the default constructor which sets it to zero. Moving it to 5minutes as a default, as zero seems redundant.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
